### PR TITLE
fix the differnce between preview and exported SDF raster

### DIFF
--- a/src/fontrender.cpp
+++ b/src/fontrender.cpp
@@ -211,9 +211,7 @@ void FontRender::run()
         baseTxtrFormat = QImage::Format_RGB32;
         glyphTxtrFormat= QImage::Format_ARGB32_Premultiplied;
     }
-    int distanceFieldScale = 4;
-    if(exporting)
-        distanceFieldScale *= 4;
+    int distanceFieldScale = 16;
     if(!distanceField)
         distanceFieldScale = 1;
     for(k = 0; k < ui->listOfFonts->count(); k++)


### PR DESCRIPTION
Классная тулза! Спасибо. Попробовал сделать SDF шрифт, но превьюшка сильно отличалась от того, что попадало в png файл, в нем буквы были компактнее. Поправил немного код, стало одинаково.
